### PR TITLE
NGSTACK-1005 upgrade bundle to ibexa 5

### DIFF
--- a/bundle/DependencyInjection/NetgenToolbarExtension.php
+++ b/bundle/DependencyInjection/NetgenToolbarExtension.php
@@ -25,8 +25,8 @@ final class NetgenToolbarExtension extends Extension implements PrependExtension
         /** @var array<string, string> $activatedBundles */
         $activatedBundles = $container->getParameter('kernel.bundles');
 
-        $activatedBundles['EzCoreExtraBundle'] ??
-            throw new RuntimeException(
+        $activatedBundles['EzCoreExtraBundle']
+            ?? throw new RuntimeException(
                 'Netgen Toolbar Bundle requires EzCoreExtraBundle (lolautruche/ez-core-extra-bundle) to be activated to work properly.',
             );
 

--- a/bundle/Resources/views/ngtoolbar.html.twig
+++ b/bundle/Resources/views/ngtoolbar.html.twig
@@ -18,7 +18,7 @@
                 </li>
             {% endif %}
 
-            {% if nglayouts is defined and nglayouts.layout is not null and (is_granted('ROLE_NGLAYOUTS_EDITOR') or is_granted('nglayouts:layout:edit', nglayouts.layout)) %}
+            {% if nglayouts.layout is not null and (is_granted('ROLE_NGLAYOUTS_EDITOR') or is_granted('nglayouts:layout:edit', nglayouts.layout)) %}
                 {% set layouts_url = url('nglayouts_' ~ (nglayouts.debug ? 'dev_' : '') ~ 'app', {
                     'siteaccess': ngtoolbar.adminSiteAccessName,
                     '_fragment': 'layout/' ~ nglayouts.layout.id.toString() }

--- a/bundle/Resources/views/ngtoolbar.html.twig
+++ b/bundle/Resources/views/ngtoolbar.html.twig
@@ -18,7 +18,7 @@
                 </li>
             {% endif %}
 
-            {% if nglayouts.layout is not null and (is_granted('ROLE_NGLAYOUTS_EDITOR') or is_granted('nglayouts:layout:edit', nglayouts.layout)) %}
+            {% if nglayouts is defined and nglayouts.layout is not null and (is_granted('ROLE_NGLAYOUTS_EDITOR') or is_granted('nglayouts:layout:edit', nglayouts.layout)) %}
                 {% set layouts_url = url('nglayouts_' ~ (nglayouts.debug ? 'dev_' : '') ~ 'app', {
                     'siteaccess': ngtoolbar.adminSiteAccessName,
                     '_fragment': 'layout/' ~ nglayouts.layout.id.toString() }

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "ibexa/core": "^4.0"
+        "php": "^8.3",
+        "ibexa/core": "^5.0"
     },
     "require-dev": {
         "php-cs-fixer/shim": "^3.50"


### PR DESCRIPTION
Upgraded bundle to use Ibexa 5 and PHP 8.3. 

In `bundle/Resources/views/ngtoolbar.html.twig` template, I just added a check to see if `nglayouts` variable is defined since I didn't use nglayouts when I tested the bundle. 